### PR TITLE
Add dialect version table support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/python/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
     -   id: black
 

--- a/zzzeeksphinx/__init__.py
+++ b/zzzeeksphinx/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 
 def setup(app):

--- a/zzzeeksphinx/autodoc_mods.py
+++ b/zzzeeksphinx/autodoc_mods.py
@@ -392,8 +392,7 @@ def missing_reference(app, env, node, contnode):
 
 
 def work_around_issue_6785():
-    """See https://github.com/sphinx-doc/sphinx/issues/6785
-    """
+    """See https://github.com/sphinx-doc/sphinx/issues/6785"""
 
     from sphinx.ext import autodoc
 

--- a/zzzeeksphinx/dialect_info.py
+++ b/zzzeeksphinx/dialect_info.py
@@ -1,10 +1,16 @@
 import re
 
 from docutils import nodes
-from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives
+from docutils.parsers.rst.directives.tables import align
+from docutils.parsers.rst.directives.tables import ListTable
+from docutils.statemachine import StringList
+from sphinx.util.docutils import SphinxDirective
+
+# see https://www.sphinx-doc.org/en/master/development/tutorials/todo.html
 
 
-class DialectDirective(Directive):
+class DialectDirective(SphinxDirective):
     has_content = True
 
     _dialects = {}
@@ -79,7 +85,7 @@ class DialectDirective(Directive):
                         "",
                         nodes.Text(text, text),
                         nodes.reference(
-                            "", "", nodes.Text(uri, uri), refuri=uri,
+                            "", "", nodes.Text(uri, uri), refuri=uri
                         ),
                     )
                 )
@@ -120,6 +126,36 @@ class DialectDirective(Directive):
 
         return output
 
+    def _build_supported_version_table(self, content):
+        if not any(
+            k in content
+            for k in ("full_support", "normal_support", "best_effort")
+        ):
+            return []
+        text = ["* - Support type", "  - Versions"]
+        if "full_support" in content:
+            text.append("* - :term:`Fully tested in CI`")
+            text.append("  - %s" % content["full_support"])
+        if "normal_support" in content:
+            text.append("* - :term:`Normal support`")
+            text.append("  - %s" % content["normal_support"])
+        if "best_effort" in content:
+            text.append("* - :term:`Best effort`")
+            text.append("  - %s" % content["best_effort"])
+
+        list_table = ListTable(
+            name="list-table",
+            arguments=["**Supported %s versions**" % content["name"]],
+            options={"header-rows": 1},
+            content=StringList(text),
+            lineno=self.lineno,
+            content_offset=self.content_offset,
+            block_text="",
+            state=self.state,
+            state_machine=self.state_machine,
+        )
+        return list_table.run()
+
     def _dialect_node(self):
         self._dialects[self.dialect_name] = self
 
@@ -132,6 +168,21 @@ class DialectDirective(Directive):
             "Please refer to individual DBAPI sections "
             "for connect information."
         )
+
+        try:
+            table = self._build_supported_version_table(content)
+        except Exception:
+            table = []
+
+        if table:
+            table = [nodes.paragraph("", "", *table)]
+            # add the dialect to the recap table only if the dialect
+            # has information to show there
+            if not hasattr(self.env, "dialect_data"):
+                self.env.dialect_data = []
+            content["sphinx_docname"] = self.env.docname
+            self.env.dialect_data.append(content)
+
         sec = nodes.section(
             "",
             nodes.paragraph(
@@ -142,6 +193,17 @@ class DialectDirective(Directive):
                     "Support for the %s database." % content["name"],
                 ),
             ),
+            nodes.paragraph(
+                "",
+                "",
+                nodes.Text(
+                    "The following table summarizes current support "
+                    "levels for database release versions.",
+                    "The following table summarizes current support "
+                    "levels for database release versions.",
+                ),
+            ),
+            *table,
             nodes.title("DBAPI Support", "DBAPI Support"),
             nodes.paragraph("", "", nodes.Text(text, text), self.bullets),
             ids=["dialect-%s" % self.dialect_name],
@@ -150,10 +212,9 @@ class DialectDirective(Directive):
         return [sec]
 
     def _append_dbapi_bullet(self, dialect_name, dbapi_name, name, idname):
-        env = self.state.document.settings.env
         dialect_directive = self._dialects[dialect_name]
         try:
-            relative_uri = env.app.builder.get_relative_uri(
+            relative_uri = self.env.app.builder.get_relative_uri(
                 dialect_directive.docname, self.docname
             )
         except:
@@ -175,8 +236,7 @@ class DialectDirective(Directive):
         dialect_directive.bullets.append(list_node)
 
     def run(self):
-        env = self.state.document.settings.env
-        self.docname = env.docname
+        self.docname = self.env.docname
 
         self.dialect_name = dialect_name = self.content[0]
 
@@ -187,5 +247,134 @@ class DialectDirective(Directive):
             return self._dialect_node()
 
 
+class dialecttable(nodes.General, nodes.Element):
+    pass
+
+
+class DialectTableDirective(SphinxDirective):
+    has_content = True
+    # from ListTable
+    final_argument_whitespace = True
+    optional_arguments = 1
+    option_spec = {
+        "header-rows": directives.nonnegative_int,
+        "class": directives.class_option,
+        "name": directives.unchanged,
+        "align": align,
+        "width": directives.length_or_percentage_or_unitless,
+        "widths": directives.value_or(
+            ("auto", "grid"), directives.positive_int_list
+        ),
+    }
+
+    def run(self):
+        node = dialecttable("")
+
+        # generate a placeholder table since in process_dialect_table
+        # there seem to be no access to state and state_machine
+
+        text = [
+            "* - Database",
+            "  - :term:`Fully tested in CI`",
+            "  - :term:`Normal support`",
+            "  - :term:`Best effort`",
+            # Mock row. Will be replaced in process_dialect_table
+            "* - **placeholder**",
+            "  - placeholder",
+            "  - placeholder",
+            "  - placeholder",
+        ]
+
+        self.options["header-rows"] = 1
+        list_table = ListTable(
+            name="list-table",
+            arguments=self.arguments,
+            options=self.options,
+            content=StringList(text),
+            lineno=self.lineno,
+            content_offset=self.content_offset,
+            block_text="",
+            state=self.state,
+            state_machine=self.state_machine,
+        )
+
+        node.extend(list_table.run())
+
+        return [node]
+
+
+def purge_dialects(app, env, docname):
+    if not hasattr(env, "dialect_data"):
+        return
+    # not sure what this does
+    env.dialect_data = [
+        dialect
+        for dialect in env.dialect_data
+        if dialect["sphinx_docname"] != docname
+    ]
+
+
+def merge_dialects(app, env, docnames, other):
+    if not hasattr(env, "dialect_data"):
+        env.dialect_data = []
+
+    if hasattr(other, "dialect_data"):
+        env.dialect_data.extend(other.dialect_data)
+
+
+def process_dialect_table(app, doctree, fromdocname):
+    # Replace all dialecttable nodes with a table with the collected data
+    env = app.builder.env
+    if not hasattr(env, "dialect_data"):
+        env.dialect_data = []
+
+    seen = set()
+    dialect_data = []
+    for d in env.dialect_data:
+        if d["name"] not in seen:
+            seen.add(d["name"])
+            dialect_data.append(d)
+
+    dialect_data.sort(key=lambda d: d["name"])
+
+    for node in doctree.traverse(dialecttable):
+        if not dialect_data:
+            node.replace_self([])
+            return
+
+        tbody = list(node.traverse(nodes.tbody))
+        assert len(tbody) == 1
+        tbody = tbody[0]
+
+        assert len(tbody) == 1
+        templateRow = tbody[0]
+        tbody.remove(templateRow)
+
+        for dialect_info in dialect_data:
+            row = templateRow.deepcopy()
+            text_to_replace = list(row.traverse(nodes.Text))
+            assert len(text_to_replace) == 4
+            columns = [
+                # TODO: it would be great for this first element to
+                # be hyperlinked
+                dialect_info["name"],
+                dialect_info.get("full_support", "-"),
+                dialect_info.get("normal_support", "-"),
+                dialect_info.get("best_effort", "-"),
+            ]
+            for text_node, col_text in zip(text_to_replace, columns):
+                text_node.parent.remove(text_node)
+
+                text_node.parent.append(nodes.Text(col_text, col_text))
+
+            tbody.append(row)
+        node.replace_self([node.children[0]])
+
+
 def setup(app):
+    app.add_node(dialecttable)
     app.add_directive("dialect", DialectDirective)
+    app.add_directive("dialect-table", DialectTableDirective)
+    app.connect("doctree-resolved", process_dialect_table)
+    app.connect("env-purge-doc", purge_dialects)
+    app.connect("env-merge-info", merge_dialects)


### PR DESCRIPTION
Extend the dialect directive to include the supported versions.

These will the used to generate a table in each dialect page like the following
![image](https://user-images.githubusercontent.com/16175304/110183230-b36f7480-7e0e-11eb-8f59-7e560b32ca48.png)

In the dialect index page it will also generate a summary table like the following
![image](https://user-images.githubusercontent.com/16175304/110183285-d732ba80-7e0e-11eb-9ddc-ee262d144d5f.png)

This table is generated using a new `dialect-table` directive

See also https://gerrit.sqlalchemy.org/c/sqlalchemy/sqlalchemy/+/2585 that uses the new features of the dialect directive