### PR TITLE
do not hide index search on mobile

### DIFF
--- a/zzzeeksphinx/themes/zzzeeksphinx/static/docs.scss
+++ b/zzzeeksphinx/themes/zzzeeksphinx/static/docs.scss
@@ -477,7 +477,7 @@ a.headerlink:hover {
 
 /* disable sidebar on mobile */
 @media only screen and (max-width: 980px) {
-  #fixed-sidebar {
+  #fixed-sidebar.withsidebar {
     display:none;
   }
   #docs-body.withsidebar {


### PR DESCRIPTION
Simple fix to avoid hiding the search in the index.html when on mobile:

![image](https://user-images.githubusercontent.com/16175304/122474841-0affad80-cfc4-11eb-82ef-1e39529b57bb.png)
