### PR TITLE
Sidenav in mobile with toggle.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .venv
 *.egg-info
 .tox
+.vscode

--- a/zzzeeksphinx/themes/zsbase/layout.mako
+++ b/zzzeeksphinx/themes/zsbase/layout.mako
@@ -59,6 +59,7 @@ withsidebar = bool(toc) and (
 
 <%block name="headers">
 
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-+0n0xVW2eSR5OomGNYDnhzAbDsOXxcvSN1TPprVMTNDbiYZCxYbOOl7+AMvyTG2x" crossorigin="anonymous">
     ${parent.headers()}
 
     <!-- begin layout.mako headers -->
@@ -81,6 +82,7 @@ withsidebar = bool(toc) and (
     % if prevtopic:
         <link rel="prev" title="${prevtopic['title']|util.striptags}" href="${prevtopic['link']|h}" />
     % endif
+
     <!-- end layout.mako headers -->
 
 </%block>
@@ -88,7 +90,13 @@ withsidebar = bool(toc) and (
 
 <div id="docs-top-navigation-container" class="body-background">
 <div id="docs-header">
+    <div>
+        <h1><a href="${pathto('index')}">${docstitle|h}</a></h1>
+        <span class="flex-grow-1"></span>
+        <a class="btn btn-light" data-bs-toggle="offcanvas" href="#fixed-sidebar" role="button" aria-controls="fixed-sidebar"> Toggle menu </a>
+    </div>
     <div id="docs-version-header">
+        <span class="flex-grow-1"></span>
         Release: <span class="version-num">${release}</span>
 
         % if is_beta_version:
@@ -108,8 +116,6 @@ withsidebar = bool(toc) and (
         % endif
 
     </div>
-
-    <h1><a href="${pathto('index')}">${docstitle|h}</a></h1>
 
 </div>
 </div>
@@ -268,7 +274,7 @@ withsidebar = bool(toc) and (
     <p><b>flambé!</b> the dragon and <b><i>The Alchemist</i></b> image designs created and generously donated by <a href="https://github.com/vmalloc">Rotem Yaari</a>.</p>
 
     % if show_sphinx:
-        Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> ${sphinx_version|h}.
+        Created using <a href="https://www.sphinx-doc.org" target="_blank">Sphinx</a> ${sphinx_version|h}.
     % endif
     </div>
 </div>
@@ -296,5 +302,6 @@ withsidebar = bool(toc) and (
 
     <script type="text/javascript" src="${pathto('_static/detectmobile.js', 1)}"></script>
     <script type="text/javascript" src="${pathto('_static/init.js', 1)}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
 
 </%block>

--- a/zzzeeksphinx/themes/zzzeeksphinx/static/docs.scss
+++ b/zzzeeksphinx/themes/zzzeeksphinx/static/docs.scss
@@ -71,6 +71,7 @@ $max-container-width: 100em; // 100 * 16 == 1600px;
 $fixed-sidebar-width: 328px;
 $docs-body-sidebar-left: 338px;
 
+$mobile-width: 980px;
 /* global */
 
 
@@ -163,13 +164,25 @@ a.headerlink:hover {
   border: $border-style;
   height: 75px;
 
-  display: flex;
-  align-items: center;
-
+  div {
+    display: flex;
+    align-items: center;
+  }
   h1 {
     font-size: 20px;
     color: #222222;
     margin-left: 10px;
+    margin-top: auto;
+    margin-bottom: auto;
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+  a.btn {
+    margin-right: 10px;
+
+    @media only screen and (min-width: $mobile-width) {
+      display: none;
+    }
   }
 }
 
@@ -187,11 +200,11 @@ a.headerlink:hover {
   padding:10px;
 }
 
-#docs-version-header {
-  position: absolute;
-  right: 8px;
-  bottom: 8px;
-}
+// #docs-version-header {
+//   position: absolute;
+//   right: 8px;
+//   bottom: 8px;
+// }
 
 .docs-navigation-links {
   font-family: $primary-font-family;
@@ -476,10 +489,7 @@ a.headerlink:hover {
 }
 
 /* disable sidebar on mobile */
-@media only screen and (max-width: 980px) {
-  #fixed-sidebar {
-    display:none;
-  }
+@media only screen and (max-width: $mobile-width) {
   #docs-body.withsidebar {
     margin-left:0;
   }

--- a/zzzeeksphinx/themes/zzzeeksphinx/static/init.js
+++ b/zzzeeksphinx/themes/zzzeeksphinx/static/init.js
@@ -108,8 +108,26 @@ function highlightLinks() {
     setLink();
 }
 
+function handleSidebar(){
+    const width = $(window).width();
+    const fixedSidebar = $("#fixed-sidebar");
+    if(width >= 980 && fixedSidebar.hasClass('offcanvas')){
+        fixedSidebar.removeClass("offcanvas offcanvas-start show hide");
+        fixedSidebar.removeAttr("tabindex");
+        fixedSidebar.removeAttr("aria-hidden");
+        fixedSidebar.removeAttr("aria-modal");
+        fixedSidebar.removeAttr("role");
+        $(".modal-backdrop").hide();
+    }
+    if(width < 980 && !fixedSidebar.hasClass('offcanvas')){
+        fixedSidebar.addClass("offcanvas offcanvas-start");
+        fixedSidebar.attr('tabindex', "-1")
+    }
+}
+
 
 $(document).ready(function() {
+    handleSidebar();
     initSQLPopups();
     if (!$.browser.mobile) {
         initFloatyThings();
@@ -117,3 +135,7 @@ $(document).ready(function() {
     }
 });
 
+
+$(window).resize(function(){
+    handleSidebar();
+})


### PR DESCRIPTION
add bootstrap and enable the sidinav using a toggle on mobile

![image](https://user-images.githubusercontent.com/16175304/122475130-7e092400-cfc4-11eb-8feb-8cec2fc7f89d.png)

still to-do before this is mergiable;
- [ ] check if we can add bootstrap as the first style sheet
- [ ] undo most style changes done by bootstrap
- [ ] disable this behavior in the index (or where there is no side sidenav)
- [ ] remove the top margin on the sidenav
- [ ] check if we can import only this part of bootstrap