### PR TITLE
[fix] improve link readability

### DIFF
--- a/zzzeeksphinx/themes/zzzeeksphinx/static/docs.scss
+++ b/zzzeeksphinx/themes/zzzeeksphinx/static/docs.scss
@@ -544,6 +544,10 @@ a.headerlink:hover {
     /* don't put a clear:both here. use less floats */
 }
 
+#docs-body a {
+    text-decoration: underline;
+}
+
 #docs-body {
     #sqlalchemy-documentation h1 {
         /* hide the <h1> for each content section. */


### PR DESCRIPTION
the link color contrast is not enough to be distinguished
improve the readability with underlined links for the docs main body content