### PR TITLE
Fix data-url_root into data-content_root

### DIFF
--- a/zzzeeksphinx/themes/zsbase/layout.mako
+++ b/zzzeeksphinx/themes/zsbase/layout.mako
@@ -84,6 +84,8 @@ withsidebar = bool(toc) and (
         <link rel="prev" title="${prevtopic['title']|util.striptags}" href="${prevtopic['link']|h}" />
     % endif
     <!-- end layout.mako headers -->
+    <script type="text/javascript" id="documentation_options" data-content_root="${ pathto('', 1) }" src="${ pathto('_static/documentation_options.js', 1) }"></script>
+
 
 </%block>
 
@@ -315,8 +317,6 @@ withsidebar = bool(toc) and (
 </div>
 
 <%block name="lower_scripts">
-
-    <script type="text/javascript" id="documentation_options" data-url_root="${ pathto('', 1) }" src="${ pathto('_static/documentation_options.js', 1) }"></script>
 
     <!-- begin iterate through sphinx environment script_files -->
     % for scriptfile in script_files + self.attr.local_script_files:

--- a/zzzeeksphinx/themes/zsmako/layout.mako
+++ b/zzzeeksphinx/themes/zsmako/layout.mako
@@ -66,6 +66,7 @@ withsidebar = bool(toc) and current_page_name != 'index'
         <link rel="prev" title="${prevtopic['title']|util.striptags}" href="${prevtopic['link']|h}" />
     % endif
     <!-- end layout.mako headers -->
+    <script type="text/javascript" id="documentation_options" data-content_root="${ pathto('', 1) }" src="${ pathto('_static/documentation_options.js', 1) }"></script>
 
 </%block>
 
@@ -208,7 +209,6 @@ withsidebar = bool(toc) and current_page_name != 'index'
       };
     </script>
 
-    <script type="text/javascript" id="documentation_options" data-url_root="${ pathto('', 1) }" src="${ pathto('_static/documentation_options.js', 1) }"></script>
 
     <!-- begin iterate through sphinx environment script_files -->
     % for scriptfile in script_files + self.attr.local_script_files:


### PR DESCRIPTION
As per this commit:
https://github.com/sphinx-doc/sphinx/commit/8e730ae303ae686705ea12f44ef11da926a87cf5

For Sphinx 7.2, url_root should be changed to content_root and moved from that <script> tag to top-level <html>.

Note that I'm not 100% sure where this <script> should be moved in the mako template, please confirm that I'm moving it correctly.