### PR TITLE
Provide reproducible build support for 'last generated' statement

### DIFF
--- a/zzzeeksphinx/themes/zsbase/layout.mako
+++ b/zzzeeksphinx/themes/zsbase/layout.mako
@@ -6,7 +6,7 @@
     from datetime import datetime, timezone
 
     generated_at = datetime.fromtimestamp(
-        timestamp=int(os.environ.get('SOURCE_DATE_EPOCH', time.time())),
+        timestamp=float(os.environ.get('SOURCE_DATE_EPOCH', time.time())),
         tz=timezone.utc if 'SOURCE_DATE_EPOCH' in os.environ else None,
     )
 

--- a/zzzeeksphinx/themes/zsbase/layout.mako
+++ b/zzzeeksphinx/themes/zsbase/layout.mako
@@ -3,10 +3,11 @@
 <%!
     import os
     import time
-    import datetime
+    from datetime import datetime, timezone
 
-    now = datetime.datetime.utcfromtimestamp(
-        int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+    generated_at = datetime.fromtimestamp(
+        timestamp=int(os.environ.get('SOURCE_DATE_EPOCH', time.time())),
+        tz=timezone.utc if 'SOURCE_DATE_EPOCH' in os.environ else None,
     )
 
     local_script_files = []
@@ -313,7 +314,7 @@ withsidebar = bool(toc) and (
         Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> ${sphinx_version|h}.
     % endif
 
-    Documentation last generated: ${now.strftime("%c")}
+    Documentation last generated: ${generated_at.strftime("%c%Z")}
 
     </div>
 </div>

--- a/zzzeeksphinx/themes/zsbase/layout.mako
+++ b/zzzeeksphinx/themes/zsbase/layout.mako
@@ -7,7 +7,7 @@
 
     generated_at = datetime.fromtimestamp(
         timestamp=float(os.environ.get('SOURCE_DATE_EPOCH', time.time())),
-        tz=timezone.utc if 'SOURCE_DATE_EPOCH' in os.environ else None,
+        tz=timezone.utc,
     )
 
     local_script_files = []

--- a/zzzeeksphinx/themes/zsbase/layout.mako
+++ b/zzzeeksphinx/themes/zsbase/layout.mako
@@ -5,10 +5,15 @@
     import time
     from datetime import datetime, timezone
 
-    generated_at = datetime.fromtimestamp(
-        timestamp=float(os.environ.get('SOURCE_DATE_EPOCH', time.time())),
-        tz=timezone.utc,
-    )
+    if "SOURCE_DATE_EPOCH" in os.environ:
+        generated_at = datetime.fromtimestamp(
+            timestamp=float(os.environ['SOURCE_DATE_EPOCH']),
+            tz=timezone.utc
+        )
+    else:
+        generated_at = datetime.fromtimestamp(
+            timestamp=time.time(),
+        ).astimezone()
 
     local_script_files = []
 

--- a/zzzeeksphinx/themes/zsbase/layout.mako
+++ b/zzzeeksphinx/themes/zsbase/layout.mako
@@ -1,7 +1,13 @@
 ## coding: utf-8
 
 <%!
+    import os
+    import time
     import datetime
+
+    now = datetime.datetime.utcfromtimestamp(
+        int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+    )
 
     local_script_files = []
 
@@ -307,7 +313,7 @@ withsidebar = bool(toc) and (
         Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> ${sphinx_version|h}.
     % endif
 
-    Documentation last generated: ${datetime.datetime.now().strftime("%c")}
+    Documentation last generated: ${now.strftime("%c")}
 
     </div>
 </div>

--- a/zzzeeksphinx/themes/zsbase/layout.mako
+++ b/zzzeeksphinx/themes/zsbase/layout.mako
@@ -319,7 +319,7 @@ withsidebar = bool(toc) and (
         Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> ${sphinx_version|h}.
     % endif
 
-    Documentation last generated: ${generated_at.strftime("%c%Z")}
+    Documentation last generated: ${generated_at.strftime("%c %Z")}
 
     </div>
 </div>


### PR DESCRIPTION
This updates the base theme layout to respect the [`SOURCE_DATE_EPOCH` reproducible build environment variable](https://reproducible-builds.org/specs/source-date-epoch/) when it is present, improving support for reproducible documentation builds.

Appearance / text format:

**Source-date-epoch timestamp**
![image](https://github.com/sqlalchemyorg/zzzeeksphinx/assets/55152140/b2f9849a-02c2-45e9-bed3-99e77b2a1a82)

**Local system timestamp**
![image](https://github.com/sqlalchemyorg/zzzeeksphinx/assets/55152140/fd3b05bd-50eb-48fe-a55d-d00b0aedc19d)

Resolves #23.