### PR TITLE
Treat empty autodoc:module the same way as None

### DIFF
--- a/zzzeeksphinx/viewsource.py
+++ b/zzzeeksphinx/viewsource.py
@@ -152,7 +152,7 @@ def vendored_env_merge_info(app, env, docnames, other):
 
 def _get_sphinx_py_module(env):
     base_name = env.temp_data.get("autodoc:module", None)
-    if base_name is not None:
+    if base_name:
         return base_name
     if util.SPHINX_VERSION >= (1, 3):
         base_name = env.ref_context.get("py:module", None)


### PR DESCRIPTION
Since Sphinx 8.2, the default value of `autodoc:module` is empty string, not None.

Because of that, sqlalchemy docs build fails while processing references like `` :viewsource:`.discriminator_on_association` ``.

Refs: https://github.com/sphinx-doc/sphinx/commit/e65bbb96ae0483ed7fb7065bce62a8a1a5d1cd0f
Refs: https://bugs.launchpad.net/bugs/2112230