### PR TITLE
Make AutoSourceDirective produce reproducible output

### DIFF
--- a/zzzeeksphinx/viewsource.py
+++ b/zzzeeksphinx/viewsource.py
@@ -317,11 +317,11 @@ class AutoSourceDirective(Directive):
 
         sourcefile = self.state.document.current_source.split(os.pathsep)[0]
         dir_ = os.path.dirname(sourcefile)
-        files = [
+        files = sorted(
             f
             for f in os.listdir(dir_)
             if f.endswith(".py") and f != "__init__.py"
-        ]
+        )
 
         if "files" in content:
             # ordered listing of files to include


### PR DESCRIPTION
This fixes one of the reproducibility problems when building sqlalchemy documentation:
https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/diffoscope-results/sqlalchemy.html

`os.listdir()` depends on filesystem order, which is not stable and can change between systems. Because of that, in the diff linked above, e.g. `greenlet_orm.py` block changes its position.

See https://reproducible-builds.org/ for more details about the reproducibility project.